### PR TITLE
Add angle brackets around URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An example app that helps enforce channel naming conventions.
 
 #### Create a Slack app
 
-1. Create a *workspace app* at (https://api.slack.com/apps?new_app_token=1)[https://api.slack.com/apps?new_app_token=1]
+1. Create a *workspace app* at <https://api.slack.com/apps?new_app_token=1>
 1. Click on `OAuth & Permissions` and add the following scopes: 
     * `channels:read` 
     * `chat:write` 
@@ -26,7 +26,7 @@ An example app that helps enforce channel naming conventions.
 #### Run locally or [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/slack-channel-naming-blueprint)
 1. Get the code
     * Either clone this repo and run `npm install`
-    * Or visit https://glitch.com/edit/#!/remix/slack-channel-naming-blueprint
+    * Or visit <https://glitch.com/edit/#!/remix/slack-channel-naming-blueprint>
 1. Set the following environment variables in `.env` (copy from `.env.sample`):
     * `SLACK_TOKEN`: Your app's `xoxa-` token (available on the Install App page)
     * `PORT`: The port that you want to run the web server on


### PR DESCRIPTION
## Why is this change necessary?

* Found a borken link in README
* Found a bare URL

## How does it address the issue?

* Add angle brackets around URLS as [markdownlint/MD034](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md034---bare-url-used) suggested